### PR TITLE
chore: update envoy to v1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM envoyproxy/envoy:v1.22.11
+FROM envoyproxy/envoy:v1.30.1
 
 RUN apt update && \
-    apt -qq -y install python && \
+    apt -qq -y install python3 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY scripts /etc/envoy

--- a/scripts/hot-restarter.py
+++ b/scripts/hot-restarter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import os


### PR DESCRIPTION
Update Envoy version to the recent one and switch hot-restarter to python3