### PR TITLE
fix: bump Envoy to v1.35.11 to patch HTTP/2 DoS (CVE-2026-47774)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.30.1
+FROM envoyproxy/envoy:v1.35.11
 
 RUN apt update && \
     apt -qq -y install python3 && \


### PR DESCRIPTION
## Issue being fixed

The image is built `FROM envoyproxy/envoy:v1.30.1`, which is affected by [GHSA-22m2-hvr2-xqc8](https://github.com/envoyproxy/envoy/security/advisories/GHSA-22m2-hvr2-xqc8) (**CVE-2026-47774**, CVSS 7.5 High).

It's an unauthenticated **HTTP/2 downstream memory-exhaustion DoS**:
- Cookie header bytes are buffered separately and merged *after* size validation, so they bypass `max_request_headers_kb`.
- HPACK/oghttp2 enforces limits on *encoded* bytes, so a small encoded header block expands to a large decoded one (amplification).

The 1.30 line is EOL — no backport exists there.

## What was done

Bumped the base image `FROM envoyproxy/envoy:v1.30.1` → `v1.35.11`.

Of the advisory's listed fix versions (`1.35.11` / `1.36.7` / `1.37.3` / `1.38.1`), **only `v1.35.11` is published upstream so far** (released + pushed to Docker Hub 2026-06-03; the others have no GitHub release and aren't on Docker Hub yet — `v1.38-latest` still points at the vulnerable `v1.38.0`). It's also the smallest jump from 1.30, so the lowest config-deprecation risk. `v1.35.11` is multi-arch (amd64 + arm64), matching the existing build platforms.

The hot-restart wrapper (`hot-restarter.py` / `start_envoy.sh`), the `python3` install, and the entrypoint are **unchanged** — only the base tag moves.

## ⚠️ Follow-up required to actually publish the patched image

Merging this **does not** publish a new `dashpay/envoy` image — the release workflow only builds/pushes on a **published GitHub release** (or `workflow_dispatch`), deriving the tag from the release tag. A maintainer needs to cut a release tagged **`v1.35.11-impr.1`** (or run the workflow manually with that tag) to produce `dashpay/envoy:1.35.11-impr.1`.

Once that image exists, the dashmate pin in `dashpay/platform` (`dashpay/envoy:1.30.2-impr.1` → `1.35.11-impr.1`) is bumped in the companion PR.

> Note: the `Dockerfile` previously pinned `v1.30.1` while the published tag was `1.30.2-impr.1` (the image tag comes from the git release tag, not `FROM`). Pinning `FROM` to exactly `v1.35.11` here keeps the published version number honest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the Docker image base to a newer version of the Envoy proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->