### PR TITLE
fix: bump Envoy to v1.39.0 to patch DoS advisories and PRIORITY flood bypass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:v1.35.11
+FROM envoyproxy/envoy:v1.39.0
 
 RUN apt update && \
     apt -qq -y install python3 && \


### PR DESCRIPTION
Bumps the base image from `envoyproxy/envoy:v1.35.11` to `envoyproxy/envoy:v1.39.0`.

v1.35.11 predates Envoy's 2026-06-23 security batch of 15 advisories. v1.39.0 closes all of them, plus an HTTP/2 flood-protection bypass that was never backported to any patch line.

## Denial of service / crash / memory exhaustion

- **HTTP/2 PRIORITY and WINDOW_UPDATE flood bypass** (no CVE assigned, envoyproxy/envoy#45077): limits scaled with the cumulative count of streams ever opened, so an attacker churning streams inflated the budget without bound and never tripped the limit. Now scales with active streams and retires on close.
- [GHSA-p7c7-7c47-pwch](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p7c7-7c47-pwch) (high): HTTP/3 QPACK blocked-decoding DoS
- [CVE-2026-48042](https://github.com/envoyproxy/envoy/security/advisories/GHSA-f24p-rxw2-g6pv) (high): stack overflow in destructor of highly nested JSON
- [CVE-2026-48044](https://github.com/envoyproxy/envoy/security/advisories/GHSA-m3p9-47wh-88wg) (high): zstd RLE zip bomb, decompressor memory explosion
- [CVE-2026-47207](https://github.com/envoyproxy/envoy/security/advisories/GHSA-68cv-hq5f-g6xv): crash on multiple ext_proc responses in one gRPC message
- [CVE-2026-47221](https://github.com/envoyproxy/envoy/security/advisories/GHSA-rcff-gw58-pjpr): null pointer deref in router internal redirects
- [CVE-2026-47204](https://github.com/envoyproxy/envoy/security/advisories/GHSA-3jxh-8p6x-7pf6): grpc_stats segfault on Connect requests to direct_response
- [CVE-2026-48090](https://github.com/envoyproxy/envoy/security/advisories/GHSA-3cj2-c63f-q26f): OAuth2 use-after-free on late async token completion
- [CVE-2026-48497](https://github.com/envoyproxy/envoy/security/advisories/GHSA-j6g2-wf95-q66q): abnormal process termination in DNS UDP filter
- [CVE-2026-48706](https://github.com/envoyproxy/envoy/security/advisories/GHSA-7q3f-gwg7-j8g4): heap buffer overflow in TcpStatsdSink on large stat names

## Also fixed

- [CVE-2026-48743](https://github.com/envoyproxy/envoy/security/advisories/GHSA-8phg-2h2q-jgxf) (high): HTTP/3 to HTTP/1 request smuggling
- [CVE-2026-47778](https://github.com/envoyproxy/envoy/security/advisories/GHSA-f8x4-rw5x-f3r7): embedded NUL TLS SAN truncation, auth bypass
- [CVE-2026-47775](https://github.com/envoyproxy/envoy/security/advisories/GHSA-396h-jpq4-vc7p): OAuth2 padding oracle, plus opt-in AES-256-GCM cookies
- [CVE-2026-47692](https://github.com/envoyproxy/envoy/security/advisories/GHSA-wh36-hm39-mm3r): PROXY protocol v2 skipped-TLV upstream spillover
- CVE-2026-47261: wasmtime bump, upstream dependency

## Why 1.39.0 rather than the minimal 1.35.13 bump

v1.35.13 closes every *published* advisory affecting the 1.35 line, and was the initial target. But the PRIORITY/WINDOW_UPDATE flood fix shipped as a behavior change under the runtime guard `envoy.reloadable_features.http2_flood_protection_active_streams`, not as an advisory, so it carries no CVE or GHSA and appears in no advisory feed. It was not backported to 1.35.13, 1.36.9, 1.37.5 or 1.38.3.

Verified by inspecting `source/common/http/http2/protocol_constraints.h` at each tag:

| Tag | PRIORITY flood fix |
|---|---|
| v1.35.13 / v1.36.9 / v1.37.5 / v1.38.3 | absent |
| **v1.39.0** | present, `RUNTIME_GUARD` = on by default |

The gateway terminates HTTP/2 from untrusted clients, so this path is reachable. Moving to 1.39.0 also resets the 12-month backport window; the 1.35 line reached the end of it (v1.35.0 shipped 2025-07-23).

CVE-2026-47205 (`>=1.36`) and CVE-2026-47220 (`>=1.37.0`) never affected 1.35, but both are fixed in 1.39.0, so the line move adds no new exposure.

## Behavior changes to validate against gateway config

- `HeaderMatcher` now evaluates repeated headers individually rather than comma-joined (revertible via `envoy.reloadable_features.match_headers_individually`)
- TLS inspector rejects client TLS versions outside 1.0-1.3
- `enforce_rsa_key_usage` is deprecated and always enforced
- OpenTelemetry tracing honors Envoy's sampling decision, which may reduce exported spans

Bazel 8 does not apply — this consumes the prebuilt image.

## Verification

Base image only. The python3 install, `scripts/{hot-restarter.py,start_envoy.sh}` and ENTRYPOINT are unchanged.

- Tag exists on Docker Hub with `linux/amd64` + `linux/arm64`, matching the multi-arch build in `release.yml`
- Image builds clean; binary reports `1.39.0`; flood-protection guard compiled in; python3 and both scripts intact
- SIGHUP hot restart exercised end to end: a new epoch started workers while the old process drained listeners — the zero-downtime path dashmate depends on

No test added: base-image version bump with no behavior delta in this repo, and there is no test suite here.

## Follow-up

Not part of this PR: release tag `v1.39.0-impr.1` publishes `dashpay/envoy:1.39.0-impr.1`, after which the dashmate pin can be bumped. The behavior changes above should be validated against the real gateway config before that pin lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Envoy runtime image to a newer version, providing the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->